### PR TITLE
the email match should be case insensitive when selecting the alias

### DIFF
--- a/packages/client-app/src/flux/stores/draft-factory.coffee
+++ b/packages/client-app/src/flux/stores/draft-factory.coffee
@@ -237,7 +237,7 @@ class DraftFactory
       alias = account.meUsingAlias(aliasString)
       for recipient in [].concat(message.to, message.cc)
         emailIsNotDefault = alias.email isnt defaultMe.email
-        emailsMatch = recipient.email is alias.email
+        emailsMatch = recipient.email.toLowerCase() is alias.email.toLowerCase()
         nameIsNotDefault = alias.name isnt defaultMe.name
         namesMatch = recipient.name is alias.name
 


### PR DESCRIPTION
The _fromContactForReply selects the right email address to fill the from field when replying to messages. The emailMatch should be case insensitive when comparing the list of alias and the to field of the email. This solves the issue for ticket https://github.com/nylas/nylas-mail/issues/3462 and https://github.com/nylas/nylas-mail/issues/3466